### PR TITLE
#8 - enable CORS support

### DIFF
--- a/KarpeLiber/settings.py
+++ b/KarpeLiber/settings.py
@@ -43,8 +43,6 @@ ALLOWED_HOSTS = CONFIG.get('ALLOWED_HOSTS', ['127.0.0.1', 'localhost'])
 # Application definition
 
 INSTALLED_APPS = [
-    # f'{MainConfig.__module__}.{MainConfig.__name__}',
-    'main.apps.MainConfig',
     'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.contenttypes',
@@ -53,9 +51,13 @@ INSTALLED_APPS = [
     'django.contrib.staticfiles',
     'django_extensions',
     'mathfilters',
+    'corsheaders',
+    # f'{MainConfig.__module__}.{MainConfig.__name__}',
+    'main.apps.MainConfig',
 ]
 
 MIDDLEWARE = [
+    'corsheaders.middleware.CorsMiddleware',
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
@@ -63,6 +65,10 @@ MIDDLEWARE = [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
+]
+
+CORS_ALLOWED_ORIGINS = [
+    'https://regents-archive-form.netlify.app',
 ]
 
 ROOT_URLCONF = 'KarpeLiber.urls'

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ psycopg2-binary>=2.8
 mysqlclient==1.4.6
 django-extensions==3.0.9
 pandas==1.1.3
+django-cors-headers
 
 # Adds Django template filters for subtraction, etc.
 django-mathfilters==1.0.0


### PR DESCRIPTION
Allow requests from Michigan Creative's Netlify-hosted sample application.