### PR TITLE
#11 - more specific URL with parameters

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /code
 COPY requirements.txt .
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-        build-essential netcat vim-tiny jq git socat \
+        build-essential netcat-traditional vim-tiny jq git socat \
         default-libmysqlclient-dev && \
     pip install -r requirements.txt
 COPY . .

--- a/main/templates/main/topics.html
+++ b/main/templates/main/topics.html
@@ -49,7 +49,7 @@
     <td>
         <p>
             {% for topic in topics %}
-            <a href="?topicId={{ topic.id }}">{{ topic }}</a>
+            <a href="/search?topicId={{ topic.id }}&searchString={{ searchString|urlencode }}&moreItems=0">{{ topic }}</a>
             ({{ topic.items.all|length }} items)<br/>
             {% endfor %}
         </p>


### PR DESCRIPTION
Use more specific URL with parameters.

Also, builds began failing recently with error about `netcat`…

```txt
#0 4.501 Package netcat is a virtual package provided by:
#0 4.501   netcat-openbsd 1.219-1
#0 4.501   netcat-traditional 1.10-47
#0 4.501
#0 4.505 E: Package 'netcat' has no installation candidate
```

According to «https://forums.docker.com/t/package-netcat-has-no-installation-candidate-how-to-fix-this/136541», the solution is to replace installation of `netcat` with `netcat-traditional` instead.  This worked in the local environment.