### PR TITLE
Improved display for missing or untitled volume (iss. #38)

### DIFF
--- a/main/templates/main/items.html
+++ b/main/templates/main/items.html
@@ -66,7 +66,12 @@
             {% else %}
             {% comment "Intentionally left blank" %}{% endcomment %}
             {% endif %}
-            Volume: {{ item.volume.title|default_if_none:"n/a" }};
+            Volume:
+            {% if not item.volume %}
+                [no volume];
+            {% else %}
+                {{ item.volume.title|default_if_none:"[untitled volume]" }};
+            {% endif %}
             Page: {{ item.page|default_if_none:"n/a" }}
             <br/>
             Found in topic area:

--- a/main/templates/main/search.html
+++ b/main/templates/main/search.html
@@ -108,7 +108,12 @@
             {% else %}
             {% comment "Intentionally left blank" %}{% endcomment %}
             {% endif %}
-            Volume: {{ item.volume.title|default_if_none:"n/a" }};
+            Volume:
+            {% if not item.volume %}
+                [no volume];
+            {% else %}
+                {{ item.volume.title|default_if_none:"[untitled volume]" }};
+            {% endif %}
             Page: {{ item.page|default_if_none:"n/a" }}
             <br/>
             Found in topic area:


### PR DESCRIPTION
Resolves #38.

Although returning `None` for the volume URL prevents HTTP 500 errors from appearing when a volume is not available, the display in the UI is not correct.  As with the other template, `[no volume]` or `[untitled volume]`. needs to be displayed at the appropriate time.